### PR TITLE
Fixes min/max not being respected with Int

### DIFF
--- a/gramfuzz/fields.py
+++ b/gramfuzz/fields.py
@@ -230,6 +230,11 @@ class Int(Field):
         """
         self.value = value
 
+        if "min" in kwargs or "max" in kwargs or "odds" in kwargs:
+            self.custom_odds = True
+        else:
+            self.custom_odds = False
+
         if "min" in kwargs or "max" in kwargs:
             self.odds = []
 
@@ -254,7 +259,7 @@ class Int(Field):
             return self.min
 
         res = self._odds_val()
-        if self.neg and rand.maybe():
+        if not self.custom_odds and self.neg and rand.maybe():
             res = -res
         return res
 

--- a/gramfuzz/fields.py
+++ b/gramfuzz/fields.py
@@ -208,15 +208,19 @@ class Int(Field):
 
     min = 0
     max = 0x10000003
-    neg = True
 
     odds = [
-        (0.75,    [0,100]),
+        (0.75,    [-100,100]),
         (0.05,    0),
+        (0.05,    [-0x80-2,-0x80+2]),
         (0.05,    [0x80-2,0x80+2]),
+        (0.05,    [-0x100-2,-0x100+2]),
         (0.05,    [0x100-2,0x100+2]),
+        (0.05,    [-0x10000-2, -0x10000+2]),
         (0.05,    [0x10000-2, 0x10000+2]),
         (0.03,    0x80000000),
+        (0.03,    -0x80000000),
+        (0.02,    [-0x100000000-2, -0x100000000+2]),
         (0.02,    [0x100000000-2, 0x100000000+2])
     ]
 
@@ -229,11 +233,6 @@ class Int(Field):
         :param list odds: The probability list. See ``Field.odds`` for more information.
         """
         self.value = value
-
-        if "min" in kwargs or "max" in kwargs or "odds" in kwargs:
-            self.custom_odds = True
-        else:
-            self.custom_odds = False
 
         if "min" in kwargs or "max" in kwargs:
             self.odds = []
@@ -258,10 +257,7 @@ class Int(Field):
         if self.min == self.max:
             return self.min
 
-        res = self._odds_val()
-        if not self.custom_odds and self.neg and rand.maybe():
-            res = -res
-        return res
+        return self._odds_val()
 
 
 class UInt(Int):
@@ -269,9 +265,31 @@ class UInt(Int):
     """
     neg = False
 
+    odds = [
+        (0.75,    [0,100]),
+        (0.05,    0),
+        (0.05,    [0x80-2,0x80+2]),
+        (0.05,    [0x100-2,0x100+2]),
+        (0.05,    [0x10000-2, 0x10000+2]),
+        (0.03,    0x80000000),
+        (0.02,    [0x100000000-2, 0x100000000+2])
+    ]
+
 class Float(Int):
     """Defines a float ``Field`` with odds that define float
     values
+    """
+    odds = [
+        (0.75,    [-100.0,100.0]),
+        (0.05,    0),
+        (0.10,    [100.0, 1000.0]),
+        (0.10,    [-1000.0, 100.0]),
+        (0.10,    [1000.0, 100000.0]),
+        (0.10,    [-100000.0, -1000.0]),
+    ]
+
+class UFloat(Float):
+    """Defines an unsigned float field.
     """
     odds = [
         (0.75,    [0.0,100.0]),
@@ -279,12 +297,6 @@ class Float(Int):
         (0.10,    [100.0, 1000.0]),
         (0.10,    [1000.0, 100000.0]),
     ]
-    neg = True
-
-class UFloat(Float):
-    """Defines an unsigned float field.
-    """
-    neg = False
 
 class String(UInt):
     """Defines a string field

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -54,6 +54,20 @@ class TestFields(unittest.TestCase):
 
     @loop
     def test_int_min_max(self):
+        min_ = 0
+        max_ = 65535
+
+        i = Int(min=min_, max=max_)
+        res = i.build()
+
+        self.assertTrue(min_ <= res < max_, "{} <= {} < {} was not True".format(
+            min_,
+            res,
+            max_
+        ))
+
+    @loop
+    def test_uint_min_max(self):
         min_ = 100
         max_ = 110
 
@@ -67,7 +81,7 @@ class TestFields(unittest.TestCase):
         ))
 
     @loop
-    def test_int_min_max2(self):
+    def test_uint_min_max2(self):
         default_min = 0
         max_ = 110
 


### PR DESCRIPTION
If min/max were set on `Int` classes, the initial generated value would be within the correct range, but would randomly be negated. The `neg` field has been removed, with the `odds` and `min`/`max` values ultimately deciding the range of generated values.

fixes #33 